### PR TITLE
Feat arweave wallet web support revamp

### DIFF
--- a/src/common/fund.ts
+++ b/src/common/fund.ts
@@ -30,7 +30,7 @@ export default class Fund {
       const baseFee = await c.getFee(c.base[0] === "winston" ? 0 : _amount, to);
       fee = BigNumber.isBigNumber(baseFee) ? baseFee.multipliedBy(multiplier).integerValue(BigNumber.ROUND_CEIL) : baseFee;
     }
-    const tx = await c.createTx(_amount, to, fee);
+    const tx = await c.createTx(_amount, to, BigNumber.isBigNumber(fee) ? fee.toString() : JSON.stringify(fee));
     let nres: any;
     // eslint-disable-next-line no-useless-catch
     try {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -2,6 +2,8 @@ import type BigNumber from "bignumber.js";
 import type { DataItem, Signer, createData, deepHash, getCryptoDriver, stringToBuffer, DataItemCreateOptions } from "arbundles";
 import type { FileDataItem } from "arbundles/file";
 import type Bundlr from "./bundlr";
+import type ArweaveWeb from "arweave/web";
+import type ArweaveNode from "arweave";
 
 // common types shared between web and node versions
 export interface CreateTxData {
@@ -46,6 +48,7 @@ export interface CurrencyConfig {
   providerUrl: string;
   isSlow?: boolean;
   opts?: any;
+  providerInstance?: ArweaveWeb | ArweaveNode;
 }
 
 export interface BundlrConfig {
@@ -54,6 +57,7 @@ export interface BundlrConfig {
   contractAddress?: string;
   currencyOpts?: object;
   headers?: Record<string, string>;
+  providerInstance?: ArweaveWeb | ArweaveNode;
 }
 
 export interface Currency {

--- a/src/web/bundlr.ts
+++ b/src/web/bundlr.ts
@@ -24,7 +24,7 @@ export default class WebBundlr extends Bundlr {
       timeout: config?.timeout ?? 100000,
       headers: config?.headers,
     });
-    this.currencyConfig = getCurrency(this, currency.toLowerCase(), provider, config?.providerUrl, config?.contractAddress);
+    this.currencyConfig = getCurrency(this, currency.toLowerCase(), provider, config?.providerUrl, config?.contractAddress, config?.providerInstance);
     this.api = new Api({ protocol: parsed.protocol.slice(0, -1), port: parsed.port, host: parsed.hostname, timeout: config?.timeout ?? 100000 });
     this.currency = this.currencyConfig.name;
     if (parsed.host === "devnet.bundlr.network" && !(config?.providerUrl || this.currencyConfig.inheritsRPC))

--- a/src/web/currencies/arweave.ts
+++ b/src/web/currencies/arweave.ts
@@ -5,7 +5,7 @@ import type { CurrencyConfig, Tx } from "../../common/types";
 import base64url from "base64url";
 import BaseWebCurrency from "../currency";
 import { SIG_CONFIG, SignatureConfig } from "arbundles/web";
-import type { Signer, JWKInterface } from "arbundles/web";
+import type { Signer } from "arbundles/web";
 
 class InjectedArweaveSigner implements Signer {
   private signer: any;
@@ -145,7 +145,7 @@ export default class ArweaveConfig extends BaseWebCurrency {
   async createTx(amount: BigNumber, to: string, fee?: string): Promise<{ txId: string | undefined; tx: any }> {
     const arweave = await this.getProvider();
     // use _address property or default to empty string
-    const tx = await arweave.createTransaction({ quantity: amount.toString(), reward: fee, target: to }, { n: this._address || "" } as JWKInterface);
+    const tx = await arweave.createTransaction({ quantity: amount.toString(), reward: fee, target: to });
     // do not pass wallet argument as it will be injected by browser wallet
     await arweave.transactions.sign(tx);
     return { txId: tx.id, tx };

--- a/src/web/currencies/arweave.ts
+++ b/src/web/currencies/arweave.ts
@@ -1,117 +1,168 @@
-// import { ArconnectSigner } from "arbundles";
-// import BigNumber from "bignumber.js";
-// import crypto from "crypto";
-// import type { CurrencyConfig, Tx } from "../../common/types";
-// import base64url from "base64url";
-// import BaseNodeCurrency from "../currency";
-// import { Arweave } from "../utils";
+import Arweave from "arweave";
+import BigNumber from "bignumber.js";
+import crypto from "crypto";
+import type { CurrencyConfig, Tx } from "../../common/types";
+import base64url from "base64url";
+import BaseWebCurrency from "../currency";
+import { SIG_CONFIG, SignatureConfig } from "arbundles/web";
+import type { Signer, JWKInterface } from "arbundles/web";
 
-// // eslint-disable-next-line @typescript-eslint/no-unused-vars
-// import type * as _ from "arconnect";
+class InjectedArweaveSigner implements Signer {
+  private signer: any;
+  public publicKey!: Buffer;
+  readonly ownerLength: number = SIG_CONFIG[SignatureConfig.ARWEAVE].pubLength;
+  readonly signatureLength: number = SIG_CONFIG[SignatureConfig.ARWEAVE].sigLength;
+  readonly signatureType = SignatureConfig.ARWEAVE;
 
-// export default class ArweaveConfig extends BaseNodeCurrency {
-//   protected declare providerInstance: Arweave;
-//   opts?: { provider?: "arconnect" | "arweave.app"; network?: string };
-//   protected declare wallet: Window["arweaveWallet"];
-//   protected signerInstance: ArconnectSigner;
-//   constructor(config: CurrencyConfig) {
-//     super(config);
-//     this.base = ["winston", 1e12];
-//     this.needsFee = true;
-//   }
+  constructor(windowArweaveWallet: any) {
+    this.signer = windowArweaveWallet;
+  }
 
-//   private async getProvider(): Promise<Arweave> {
-//     if (!this.providerInstance) {
-//       const purl = new URL(this.providerUrl ?? "https://arweave.net");
-//       let config;
-//       try {
-//         config = this.wallet.getArweaveConfig();
-//       } catch (e) {}
-//       this.providerInstance = Arweave.init(
-//         config ?? {
-//           host: purl.hostname,
-//           protocol: purl.protocol.replaceAll(":", "").replaceAll("/", ""),
-//           port: purl.port,
-//           network: this?.opts?.network,
-//         },
-//       );
-//     }
-//     return this.providerInstance;
-//   }
+  async setPublicKey(): Promise<void> {
+    const arOwner = await this.signer.getActivePublicKey();
+    this.publicKey = base64url.toBuffer(arOwner);
+  }
 
-//   async getTx(txId: string): Promise<Tx> {
-//     const arweave = await this.getProvider();
-//     const txs = await arweave.transactions.getStatus(txId);
-//     let tx;
-//     if (txs.status === 200) {
-//       tx = await arweave.transactions.get(txId);
-//     }
-//     const confirmed = txs.status !== 202 && (txs.confirmed?.number_of_confirmations ?? 0) >= this.minConfirm;
-//     let owner;
-//     if (tx?.owner) {
-//       owner = this.ownerToAddress(tx.owner);
-//     }
-//     return {
-//       from: owner ?? undefined,
-//       to: tx?.target ?? undefined,
-//       amount: new BigNumber(tx?.quantity ?? 0),
-//       pending: txs.status === 202,
-//       confirmed,
-//     };
-//   }
+  async sign(message: Uint8Array): Promise<Uint8Array> {
+    if (!this.publicKey) {
+      await this.setPublicKey();
+    }
 
-//   ownerToAddress(owner: any): string {
-//     return Arweave.utils.bufferTob64Url(
-//       crypto
-//         .createHash("sha256")
-//         .update(Arweave.utils.b64UrlToBuffer(Buffer.isBuffer(owner) ? base64url(owner) : owner))
-//         .digest(),
-//     );
-//   }
+    const algorithm = {
+      name: "RSA-PSS",
+      saltLength: 0,
+    };
 
-//   async sign(data: Uint8Array): Promise<Uint8Array> {
-//     return this.getSigner().sign(data);
-//   }
+    const signature = await this.signer.signature(message, algorithm);
+    const buf = new Uint8Array(Object.values(signature));
+    return buf;
+  }
 
-//   getSigner(): ArconnectSigner {
-//     if (this.signerInstance) return this.signerInstance;
-//     switch (this?.opts?.provider ?? "arconnect") {
-//       case "arconnect":
-//         this.signerInstance = new ArconnectSigner(this.wallet);
-//     }
-//     return this.signerInstance;
-//   }
+  static async verify(pk: string, message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+    return await Arweave.crypto.verify(pk, message, signature);
+  }
 
-//   async verify(pub: any, data: Uint8Array, signature: Uint8Array): Promise<boolean> {
-//     if (Buffer.isBuffer(pub)) {
-//       pub = pub.toString();
-//     }
-//     return Arweave.crypto.verify(pub, data, signature);
-//   }
+  async refresh(wallet: any): Promise<void> {
+    this.signer = wallet;
+    await this.setPublicKey();
+  }
+}
 
-//   async getCurrentHeight(): Promise<BigNumber> {
-//     return (await this.getProvider()).network.getInfo().then((r) => new BigNumber(r.height));
-//   }
+export default class ArweaveConfig extends BaseWebCurrency {
+  protected signer!: InjectedArweaveSigner;
+  protected declare providerInstance?: Arweave;
+  protected declare wallet: Window["arweaveWallet"];
+  opts?: { provider?: "arconnect" | "arweave.app"; network?: string };
 
-//   async getFee(amount: BigNumber.Value, to?: string): Promise<BigNumber> {
-//     return new BigNumber(await (await this.getProvider()).transactions.getPrice(new BigNumber(amount).toNumber(), to)).integerValue(
-//       BigNumber.ROUND_CEIL,
-//     );
-//   }
+  constructor(config: CurrencyConfig) {
+    super(config);
+    this.base = ["winston", 1e12];
+    this.needsFee = true;
+  }
 
-//   async sendTx(data: any): Promise<any> {
-//     return await (await this.getProvider()).transactions.post(data);
-//   }
+  private async getProvider(): Promise<Arweave> {
+    if (!this.providerInstance) {
+      const purl = new URL(this.providerUrl ?? "https://arweave.net");
+      let config;
+      try {
+        config = this.wallet.getArweaveConfig();
+      } catch (e) {}
+      this.providerInstance = Arweave.init(
+        config ?? {
+          host: purl.hostname,
+          protocol: purl.protocol.replaceAll(":", "").replaceAll("/", ""),
+          port: purl.port,
+          network: this?.opts?.network,
+        },
+      );
+      this.providerInstance = Arweave.init({ host: purl.hostname, protocol: purl.protocol.replaceAll(":", "").replaceAll("/", ""), port: purl.port });
+    }
+    return this.providerInstance;
+  }
 
-//   async createTx(amount: BigNumber.Value, to: string, fee?: string): Promise<{ txId: string | undefined; tx: any }> {
-//     const arweave = await this.getProvider();
-//     const tx = await this.wallet.sign(await arweave.createTransaction({ quantity: new BigNumber(amount).toString(), reward: fee, target: to }));
-//     return { txId: tx.id, tx };
-//   }
+  async getTx(txId: string): Promise<Tx> {
+    const arweave = await this.getProvider();
+    const txs = await arweave.transactions.getStatus(txId);
+    let tx;
+    if (txs.status == 200) {
+      tx = await arweave.transactions.get(txId);
+    }
+    const confirmed = txs.status !== 202 && (txs.confirmed?.number_of_confirmations ?? 0) >= this.minConfirm;
+    let owner;
+    if (tx?.owner) {
+      owner = this.ownerToAddress(tx.owner);
+    }
+    return {
+      from: owner ?? undefined,
+      to: tx?.target ?? undefined,
+      amount: new BigNumber(tx?.quantity ?? 0),
+      pending: txs.status == 202,
+      confirmed,
+    };
+  }
 
-//   async getPublicKey(): Promise<string> {
-//     const signer = this.getSigner();
-//     await signer.setPublicKey();
-//     return Arweave.utils.bufferTob64Url(signer.publicKey);
-//   }
-// }
+  ownerToAddress(owner: any): string {
+    return Arweave.utils.bufferTob64Url(
+      crypto
+        .createHash("sha256")
+        .update(Arweave.utils.b64UrlToBuffer(Buffer.isBuffer(owner) ? base64url(owner) : owner))
+        .digest(),
+    );
+  }
+
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return Arweave.crypto.sign(this.wallet as any, data);
+  }
+
+  getSigner(): Signer {
+    if (!this.signer) {
+      this.signer = new InjectedArweaveSigner(this.wallet);
+    }
+    return this.signer;
+  }
+
+  async verify(pub: any, data: Uint8Array, signature: Uint8Array): Promise<boolean> {
+    if (Buffer.isBuffer(pub)) {
+      pub = pub.toString();
+    }
+    return Arweave.crypto.verify(pub, data, signature);
+  }
+
+  async getCurrentHeight(): Promise<BigNumber> {
+    return (await this.getProvider()).network.getInfo().then((r) => new BigNumber(r.height));
+  }
+
+  async getFee(amount: BigNumber.Value, to?: string): Promise<BigNumber> {
+    return new BigNumber(await (await this.getProvider()).transactions.getPrice(new BigNumber(amount).toNumber(), to)).integerValue(
+      BigNumber.ROUND_CEIL,
+    );
+  }
+
+  async sendTx(data: any): Promise<any> {
+    return await (await this.getProvider()).transactions.post(data);
+  }
+
+  async createTx(amount: BigNumber, to: string, fee?: string): Promise<{ txId: string | undefined; tx: any }> {
+    const arweave = await this.getProvider();
+    // use _address property or default to empty string
+    const tx = await arweave.createTransaction({ quantity: amount.toString(), reward: fee, target: to }, { n: this._address || "" } as JWKInterface);
+    // do not pass wallet argument as it will be injected by browser wallet
+    await arweave.transactions.sign(tx);
+    return { txId: tx.id, tx };
+  }
+
+  async getPublicKey(): Promise<string | Buffer> {
+    const signer = (await this.getSigner()) as InjectedArweaveSigner;
+    await signer.setPublicKey();
+    return signer.publicKey;
+  }
+
+  public async ready(): Promise<void> {
+    await this.getSigner();
+    await this.signer.setPublicKey();
+    this._address = this.ownerToAddress(await this.getPublicKey());
+    this.providerInstance = await this.getProvider();
+
+    await this.providerInstance.network.getInfo();
+  }
+}

--- a/src/web/currencies/index.ts
+++ b/src/web/currencies/index.ts
@@ -9,6 +9,8 @@ import utils from "../../common/utils";
 import AptosConfig from "./aptos";
 import type WebBundlr from "web";
 import ArweaveConfig from "./arweave";
+import ArweaveWeb from "arweave/web";
+import ArweaveNode from "arweave";
 
 export default function getCurrency(
   bundlr: WebBundlr,
@@ -16,10 +18,15 @@ export default function getCurrency(
   wallet: any,
   providerUrl?: string,
   contractAddress?: string,
+  providerInstance?: ArweaveNode | ArweaveWeb,
   // opts?: any,
 ): BaseCurrency {
   switch (currency) {
     case "arweave":
+      if (!providerInstance) throw new Error("Must provide an Arweave instance");
+      if (!(providerInstance instanceof ArweaveNode) || !(providerInstance instanceof ArweaveWeb)) {
+        throw new Error("Invalid Provider instance. Please make sure you are using the correct Arweave SDK version.");
+      }
       return new ArweaveConfig({
         bundlr,
         name: "arweave",
@@ -28,6 +35,7 @@ export default function getCurrency(
         providerUrl: providerUrl ?? "https://arweave.net",
         wallet,
         isSlow: true,
+        providerInstance,
       });
     case "ethereum":
       return new EthereumConfig({ bundlr, name: "ethereum", ticker: "ETH", providerUrl: providerUrl ?? "https://cloudflare-eth.com/", wallet });

--- a/src/web/currencies/index.ts
+++ b/src/web/currencies/index.ts
@@ -8,7 +8,7 @@ import axios from "axios";
 import utils from "../../common/utils";
 import AptosConfig from "./aptos";
 import type WebBundlr from "web";
-// import ArweaveConfig from "./arweave";
+import ArweaveConfig from "./arweave";
 
 export default function getCurrency(
   bundlr: WebBundlr,
@@ -19,17 +19,16 @@ export default function getCurrency(
   // opts?: any,
 ): BaseCurrency {
   switch (currency) {
-    // case "arweave":
-    //   return new ArweaveConfig({
-    //     bundlr,
-    //     name: "arweave",
-    //     ticker: "AR",
-    //     minConfirm: 10,
-    //     providerUrl: providerUrl ?? "https://arweave.net",
-    //     wallet,
-    //     isSlow: true,
-    //     opts,
-    //   });
+    case "arweave":
+      return new ArweaveConfig({
+        bundlr,
+        name: "arweave",
+        ticker: "AR",
+        minConfirm: 10,
+        providerUrl: providerUrl ?? "https://arweave.net",
+        wallet,
+        isSlow: true,
+      });
     case "ethereum":
       return new EthereumConfig({ bundlr, name: "ethereum", ticker: "ETH", providerUrl: providerUrl ?? "https://cloudflare-eth.com/", wallet });
     case "matic":

--- a/src/web/currencies/index.ts
+++ b/src/web/currencies/index.ts
@@ -9,8 +9,8 @@ import utils from "../../common/utils";
 import AptosConfig from "./aptos";
 import type WebBundlr from "web";
 import ArweaveConfig from "./arweave";
-import ArweaveWeb from "arweave/web";
-import ArweaveNode from "arweave";
+import type ArweaveWeb from "arweave/web";
+import type ArweaveNode from "arweave";
 
 export default function getCurrency(
   bundlr: WebBundlr,
@@ -24,9 +24,6 @@ export default function getCurrency(
   switch (currency) {
     case "arweave":
       if (!providerInstance) throw new Error("Must provide an Arweave instance");
-      if (!(providerInstance instanceof ArweaveNode) || !(providerInstance instanceof ArweaveWeb)) {
-        throw new Error("Invalid Provider instance. Please make sure you are using the correct Arweave SDK version.");
-      }
       return new ArweaveConfig({
         bundlr,
         name: "arweave",


### PR DESCRIPTION
Allows for arconnect and arweave.app support using web bundlr

## Usage
```typescript

// requires you to have an arweave initialisation beforehand
const arweave = Arweave.init({
  host: NET_ARWEAVE_URL.split('//')[1],
  port: 443,
  protocol: 'https',
});

// arweave.app
 const arweaveApp = new ArweaveWebWallet({
  // optionally provide information about your app that will be displayed in the wallet provider interface
  name: 'Your app Name',
  logo: 'https://7kekrsiqzdrmjh222sx5xohduoemsoosicy33nqic4q5rbdcqybq.arweave.net/-oioyRDI4sSfWtSv27jjo4jJOdJAsb22CBch2IRihgM',
});

const arConnect = window.arweaveWallet;

const walletInstance = arweaveApp || arConnect;

const bundlr = new WebBundlr(node, 'arweave', walletInstance, { providerInstance: arweave });
try {
    await bundlr.ready();
  } catch (error) {
    console.log(error);
  }
```