### PR TITLE
Migrate to `@aptos-labs/ts-sdk`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "node": ">=16.10.0"
   },
   "dependencies": {
+    "@aptos-labs/ts-sdk": "^1.6.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
@@ -116,7 +117,6 @@
     "@solana/web3.js": "^1.36.0",
     "@supercharge/promise-pool": "^3.0.0",
     "algosdk": "^1.13.1",
-    "aptos": "=1.8.5",
     "arbundles": "^0.10.0",
     "async-retry": "^1.3.3",
     "axios": "^1.6.7",

--- a/src/node/tokens/aptos.ts
+++ b/src/node/tokens/aptos.ts
@@ -1,24 +1,35 @@
-import {
-  AptosAccount,
-  AptosClient,
-  TransactionBuilder,
-  TransactionBuilderEd25519,
-  TransactionBuilderRemoteABI,
-  TxnBuilderTypes /* BCS, TxnBuilderTypes */,
-} from "aptos";
 import type { Signer } from "arbundles";
 import { AptosSigner } from "arbundles";
 import BigNumber from "bignumber.js";
 import type { TokenConfig, Tx } from "../../common/types";
 import { BaseNodeToken } from "../token";
 import sha3 from "js-sha3";
+import {
+  Aptos,
+  AptosConfig as AptosSDKConfig,
+  Account,
+  MimeType,
+  postAptosFullNode,
+  PendingTransactionResponse,
+  generateSignedTransaction,
+  Ed25519PublicKey,
+  Ed25519PrivateKey,
+  Secp256k1PrivateKey,
+  TransactionAuthenticatorEd25519,
+  AccountAuthenticatorEd25519,
+  Ed25519Signature,
+  SignedTransaction,
+  UserTransactionResponse,
+  generateSigningMessage,
+} from "@aptos-labs/ts-sdk";
 import AsyncRetry from "async-retry";
 // import { Transaction_UserTransaction, TransactionPayload_EntryFunctionPayload, UserTransaction, } from "aptos/src/generated";
 
 export default class AptosConfig extends BaseNodeToken {
-  protected declare providerInstance?: AptosClient;
-  protected accountInstance: AptosAccount | undefined;
+  protected declare providerInstance?: Aptos;
+  protected accountInstance: Account | undefined;
   protected signerInstance: AptosSigner | undefined;
+  protected aptosConfig: AptosSDKConfig;
   protected declare signingFn: (msg: Uint8Array) => Promise<Uint8Array>;
   declare opts: any;
   protected txLock: Promise<unknown> = Promise.resolve();
@@ -26,9 +37,9 @@ export default class AptosConfig extends BaseNodeToken {
 
   constructor(config: TokenConfig) {
     if (typeof config.wallet === "string" && config.wallet.length === 66) config.wallet = Buffer.from(config.wallet.slice(2), "hex");
-    if (!config?.opts?.signingFunction && Buffer.isBuffer(config?.wallet)) {
+    if (!config?.opts?.signingFunction && (config?.wallet instanceof Ed25519PrivateKey || config?.wallet instanceof Secp256k1PrivateKey)) {
       // @ts-expect-error custom prop
-      config.accountInstance = new AptosAccount(config.wallet);
+      config.accountInstance = Account.fromPrivateKey({ privateKey: config?.wallet });
     }
     super(config);
     // @ts-expect-error assignment doesn't carry through for some reason
@@ -36,15 +47,19 @@ export default class AptosConfig extends BaseNodeToken {
     this.signingFn = config?.opts?.signingFunction;
     this.needsFee = true;
     this.base = ["aptom", 1e8];
+
+    // In the Aptos context, this.providerUrl is the Aptos Network we want
+    // to work with. read more https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/aptosConfig.ts#L14
+    this.aptosConfig = new AptosSDKConfig({ network: this.providerUrl });
   }
 
-  async getProvider(): Promise<AptosClient> {
-    return (this.providerInstance ??= new AptosClient(this.providerUrl));
+  async getProvider(): Promise<Aptos> {
+    return (this.providerInstance ??= new Aptos(this.aptosConfig));
   }
 
   async getTx(txId: string): Promise<Tx> {
     const client = await this.getProvider();
-    const tx = (await client.waitForTransactionWithResult(txId /* , { checkSuccess: true } */)) as any;
+    const tx = (await client.waitForTransaction({ transactionHash: txId })) as any;
     const payload = tx?.payload as any;
 
     if (!tx.success) {
@@ -88,10 +103,7 @@ export default class AptosConfig extends BaseNodeToken {
       signer.sign = this.signingFn; // override signer fn
       return (this.signerInstance = signer);
     } else {
-      return (this.signerInstance = new AptosSigner(
-        this.accountInstance!.toPrivateKeyObject().privateKeyHex,
-        this.accountInstance!.toPrivateKeyObject().publicKeyHex!,
-      ));
+      return (this.signerInstance = new AptosSigner(this.accountInstance!.privateKey.toString(), this.accountInstance!.publicKey.toString()));
     }
   }
 
@@ -100,51 +112,49 @@ export default class AptosConfig extends BaseNodeToken {
   }
 
   async getCurrentHeight(): Promise<BigNumber> {
-    return new BigNumber(
-      ((await (await this.getProvider()).client.blocks.httpRequest.request({ method: "GET", url: "/" })) as { block_height: string }).block_height,
-    );
+    return new BigNumber(((await (await this.getProvider()).getLedgerInfo()) as { block_height: string }).block_height);
   }
 
   async getFee(amount: BigNumber.Value, to?: string): Promise<{ gasUnitPrice: number; maxGasAmount: number }> {
     if (!this.address) throw new Error("Address is undefined - you might be missing a wallet, or have not run Irys.ready()");
     const client = await this.getProvider();
 
-    const builder = new TransactionBuilderRemoteABI(client, { sender: this.address });
+    const transaction = await client.transaction.build.simple({
+      sender: this.address,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: [to ?? "0x149f7dc9c8e43c14ab46d3a6b62cfe84d67668f764277411f98732bf6718acf9", new BigNumber(amount).toNumber()],
+      },
+    });
 
-    const rawTransaction = await builder.build(
-      "0x1::coin::transfer",
-      ["0x1::aptos_coin::AptosCoin"],
-      [to ?? "0x149f7dc9c8e43c14ab46d3a6b62cfe84d67668f764277411f98732bf6718acf9", new BigNumber(amount).toNumber()],
-    );
+    const accountAuthenticator = new AccountAuthenticatorEd25519(new Ed25519PublicKey(this.getPublicKey()), new Ed25519Signature(new Uint8Array(64)));
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const txnBuilder = new TransactionBuilderEd25519((_signingMessage: TxnBuilderTypes.SigningMessage) => {
-      const invalidSigBytes = new Uint8Array(64);
-      return new TxnBuilderTypes.Ed25519Signature(invalidSigBytes);
-    }, this.getPublicKey() as Buffer);
+    const transactionAuthenticator = new TransactionAuthenticatorEd25519(accountAuthenticator.public_key, accountAuthenticator.signature);
 
-    const signedSimulation = txnBuilder.sign(rawTransaction);
+    const signedSimulation = new SignedTransaction(transaction.rawTransaction, transactionAuthenticator).bcsToBytes();
 
     const queryParams = {
       estimate_gas_unit_price: true,
       estimate_max_gas_amount: true,
     };
-    const simulationResult = await AsyncRetry(
+    const [simulationResult] = await AsyncRetry(
       async (_) => {
-        const simulationResult = await client.client.request.request<any[]>({
-          url: "/transactions/simulate",
-          query: queryParams,
-          method: "POST",
+        const { data } = await postAptosFullNode<Uint8Array, Array<UserTransactionResponse>>({
+          aptosConfig: this.aptosConfig,
           body: signedSimulation,
-          mediaType: "application/x.aptos.signed_transaction+bcs",
+          path: "transactions/simulate",
+          params: queryParams,
+          originMethod: "simulateTransaction",
+          contentType: MimeType.BCS_SIGNED_TRANSACTION,
         });
-        if (!simulationResult[0].success || simulationResult[0].gas_used === "0") throw new Error(`Tx simulation failed`);
-        return simulationResult;
+        if (!data[0].success || data[0].gas_used === "0") throw new Error(`Tx simulation failed`);
+        return data;
       },
       { retries: 10 },
     ).catch((_) => [{ gas_unit_price: "100", gas_used: "10" }]);
 
-    return { gasUnitPrice: +simulationResult[0].gas_unit_price, maxGasAmount: Math.ceil(+simulationResult[0].gas_used * 2) };
+    return { gasUnitPrice: +simulationResult.gas_unit_price, maxGasAmount: Math.ceil(+simulationResult.gas_used * 2) };
 
     // const simulationResult = await client.simulateTransaction(this.accountInstance, rawTransaction, { estimateGasUnitPrice: true, estimateMaxGasAmount: true });
     // return new BigNumber(simulationResult?.[0].gas_unit_price).multipliedBy(simulationResult?.[0].gas_used);
@@ -154,10 +164,18 @@ export default class AptosConfig extends BaseNodeToken {
 
   async sendTx(data: { tx: Uint8Array; unlock?: () => void }): Promise<string | undefined> {
     const provider = await this.getProvider();
-    const s = await provider.submitSignedBCSTransaction(data.tx);
-    await provider.waitForTransactionWithResult(s.hash);
+
+    const { data: postData } = await postAptosFullNode<Uint8Array, PendingTransactionResponse>({
+      aptosConfig: this.aptosConfig,
+      body: data.tx,
+      path: "transactions",
+      originMethod: "submitTransaction",
+      contentType: MimeType.BCS_SIGNED_TRANSACTION,
+    });
+
+    await provider.waitForTransaction({ transactionHash: postData.hash });
     data.unlock?.();
-    return s.hash;
+    return postData.hash;
   }
 
   async createTx(
@@ -170,36 +188,40 @@ export default class AptosConfig extends BaseNodeToken {
     const unlock = await this.lock();
 
     const client = await this.getProvider();
-    const builder = new TransactionBuilderRemoteABI(client, {
+
+    const transaction = await client.transaction.build.simple({
       sender: this.address,
-      gasUnitPrice: BigInt(fee?.gasUnitPrice ?? 100),
-      maxGasAmount: BigInt(fee?.maxGasAmount ?? 10),
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: [to, new BigNumber(amount).toNumber()],
+      },
+      options: {
+        gasUnitPrice: fee?.gasUnitPrice ?? 100,
+        maxGasAmount: fee?.maxGasAmount ?? 10,
+      },
     });
-    const rawTransaction = await builder.build("0x1::coin::transfer", ["0x1::aptos_coin::AptosCoin"], [to, new BigNumber(amount).toNumber()]);
 
-    // const bcsTxn = AptosClient.generateBCSTransaction(this.accountInstance, rawTransaction);
+    const message = generateSigningMessage(transaction);
 
-    const signingMessage = TransactionBuilder.getSigningMessage(rawTransaction);
-    const sig = await this.sign(signingMessage);
+    const signerSignature = await this.sign(message);
 
-    const txnBuilder = new TransactionBuilderEd25519((_) => {
-      return new TxnBuilderTypes.Ed25519Signature(sig);
-    }, this.getPublicKey() as Buffer);
+    const senderAuthenticator = new AccountAuthenticatorEd25519(new Ed25519PublicKey(this.getPublicKey()), new Ed25519Signature(signerSignature));
 
-    const bcsTxn = txnBuilder.sign(rawTransaction);
+    const signedTransaction = generateSignedTransaction({ transaction, senderAuthenticator });
 
-    return { txId: undefined, tx: { tx: bcsTxn, unlock } };
+    return { txId: undefined, tx: { tx: signedTransaction, unlock } };
   }
 
   getPublicKey(): string | Buffer {
     if (this.opts?.signingFunction) return this.wallet;
-    return Buffer.from(this.accountInstance!.pubKey().toString().slice(2), "hex");
+    return Buffer.from(this.accountInstance!.publicKey.toUint8Array());
   }
 
   async ready(): Promise<void> {
     const client = await this.getProvider();
     this._address = await client
-      .lookupOriginalAddress(this.address ?? "")
+      .lookupOriginalAccountAddress({ authenticationKey: this.address ?? "" })
       .then((hs) => hs.toString())
       .catch((_) => this._address); // fallback to original
 

--- a/src/node/tokens/multiAptos.ts
+++ b/src/node/tokens/multiAptos.ts
@@ -1,18 +1,32 @@
-import {
-  TransactionBuilder,
-  TransactionBuilderMultiEd25519,
-  TxnBuilderTypes,
-  BCS,
-  AptosAccount,
-  TransactionBuilderEd25519,
-  TransactionBuilderRemoteABI,
-} from "aptos";
 import BigNumber from "bignumber.js";
 import type { TokenConfig } from "../../common/types";
 import Aptos from "./aptos";
 import type { Signer } from "arbundles";
 import { MultiSignatureAptosSigner } from "arbundles";
-// import { UserTransaction } from "aptos/src/generated";
+import {
+  AccountAddress,
+  AuthenticationKey,
+  ChainId,
+  Ed25519PublicKey,
+  MimeType,
+  Ed25519Signature,
+  EntryFunction,
+  MultiEd25519PublicKey,
+  MultiEd25519Signature,
+  PendingTransactionResponse,
+  RawTransaction,
+  SignedTransaction,
+  SigningScheme,
+  TransactionAuthenticatorMultiEd25519,
+  TransactionPayloadEntryFunction,
+  U64,
+  generateSigningMessage,
+  parseTypeTag,
+  postAptosFullNode,
+  AccountAuthenticatorEd25519,
+  TransactionAuthenticatorEd25519,
+  UserTransactionResponse,
+} from "@aptos-labs/ts-sdk";
 // import Utils from "../../common/utils";
 
 export type HexString = string;
@@ -36,20 +50,20 @@ export default class MultiSignatureAptos extends Aptos {
     const multiSigPublicKey = this.deserialisePubKey(pubKey);
 
     // derive address
-    const authKey2 = TxnBuilderTypes.AuthenticationKey.fromMultiEd25519PublicKey(multiSigPublicKey);
+    const authKey2 = AuthenticationKey.fromPublicKeyAndScheme({ publicKey: multiSigPublicKey, scheme: SigningScheme.MultiEd25519 });
     return authKey2.derivedAddress().toString();
   }
 
-  protected deserialisePubKey(pubKey: Buffer): TxnBuilderTypes.MultiEd25519PublicKey {
+  protected deserialisePubKey(pubKey: Buffer): MultiEd25519PublicKey {
     const threshold = +pubKey.slice(32 * 32).toString();
     const keys = [] as /* Ed25519PublicKey */ any[];
     const nullBuf = Buffer.alloc(32, 0);
     for (let i = 0; i < 32; i++) {
       const key = pubKey.subarray(i * 32, (i + 1) * 32);
-      if (!key.equals(nullBuf)) keys.push(new TxnBuilderTypes.Ed25519PublicKey(key));
+      if (!key.equals(nullBuf)) keys.push(new Ed25519PublicKey(key));
     }
     // reconstruct key
-    return new TxnBuilderTypes.MultiEd25519PublicKey(keys, threshold);
+    return new MultiEd25519PublicKey({ publicKeys: keys, threshold });
   }
 
   getPublicKey(): string | Buffer {
@@ -69,36 +83,36 @@ export default class MultiSignatureAptos extends Aptos {
 
     if (!this.address) throw new Error("Address is undefined - you might be missing a wallet, or have not run Irys.ready()");
 
-    const builder = new TransactionBuilderRemoteABI(client, { sender: this.address });
+    const transaction = await client.transaction.build.simple({
+      sender: this.address,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: [to ?? "0x149f7dc9c8e43c14ab46d3a6b62cfe84d67668f764277411f98732bf6718acf9", new BigNumber(amount).toNumber()],
+      },
+    });
 
-    const rawTransaction = await builder.build(
-      "0x1::coin::transfer",
-      ["0x1::aptos_coin::AptosCoin"],
-      [to ?? "0x149f7dc9c8e43c14ab46d3a6b62cfe84d67668f764277411f98732bf6718acf9", new BigNumber(amount).toNumber()],
-    );
+    const accountAuthenticator = new AccountAuthenticatorEd25519(new Ed25519PublicKey(this.getPublicKey()), new Ed25519Signature(new Uint8Array(64)));
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const txnBuilder = new TransactionBuilderEd25519((_signingMessage: TxnBuilderTypes.SigningMessage) => {
-      const invalidSigBytes = new Uint8Array(64);
-      return new TxnBuilderTypes.Ed25519Signature(invalidSigBytes);
-    }, new Uint8Array(32));
+    const transactionAuthenticator = new TransactionAuthenticatorEd25519(accountAuthenticator.public_key, accountAuthenticator.signature);
 
-    const signedSimulation = txnBuilder.sign(rawTransaction);
+    const signedSimulation = new SignedTransaction(transaction.rawTransaction, transactionAuthenticator).bcsToBytes();
 
     const queryParams = {
       estimate_gas_unit_price: true,
       estimate_max_gas_amount: true,
     };
 
-    const simulationResult = await client.client.request.request<any[]>({
-      url: "/transactions/simulate",
-      query: queryParams,
-      method: "POST",
+    const { data } = await postAptosFullNode<Uint8Array, Array<UserTransactionResponse>>({
+      aptosConfig: this.aptosConfig,
       body: signedSimulation,
-      mediaType: "application/x.aptos.signed_transaction+bcs",
+      path: "transactions/simulate",
+      params: queryParams,
+      originMethod: "simulateTransaction",
+      contentType: MimeType.BCS_SIGNED_TRANSACTION,
     });
 
-    return { gasUnitPrice: +simulationResult[0].gas_unit_price, maxGasAmount: +simulationResult[0].max_gas_amount };
+    return { gasUnitPrice: +data[0].gas_unit_price, maxGasAmount: +data[0].max_gas_amount };
   }
 
   async createTx(
@@ -109,43 +123,37 @@ export default class MultiSignatureAptos extends Aptos {
     const client = await this.getProvider();
     const { participants, threshold } = this.wallet;
 
-    const multiSigPublicKey = new TxnBuilderTypes.MultiEd25519PublicKey(
-      participants.map((v) => new TxnBuilderTypes.Ed25519PublicKey(v)),
-      threshold,
-    );
+    const multiSigPublicKey = new MultiEd25519PublicKey({ publicKeys: participants.map((v) => new Ed25519PublicKey(v)), threshold });
 
-    const authKey = TxnBuilderTypes.AuthenticationKey.fromMultiEd25519PublicKey(multiSigPublicKey);
+    const authKey = AuthenticationKey.fromPublicKeyAndScheme({ publicKey: multiSigPublicKey, scheme: SigningScheme.MultiEd25519 });
     const mutisigAccountAddress = authKey.derivedAddress();
 
-    const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin"));
+    const token = parseTypeTag("0x1::aptos_coin::AptosCoin");
 
-    const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
-      TxnBuilderTypes.EntryFunction.natural(
-        // Fully qualified module name, `AccountAddress::ModuleName`
-        "0x1::coin",
-        // Module function
-        "transfer",
-        // The coin type to transfer
-        [token],
-        // Arguments for function `transfer`: receiver account address and amount to transfer
-        [BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(to)), BCS.bcsSerializeUint64(new BigNumber(amount).toNumber())],
-      ),
+    const entryFunctionPayload = EntryFunction.build(
+      `0x1::coin`,
+      `transfer`,
+      [token],
+      [AccountAddress.from(to), new U64(new BigNumber(amount).toNumber())],
     );
 
-    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([client.getAccount(mutisigAccountAddress), client.getChainId()]);
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
+      client.getAccountInfo({ accountAddress: mutisigAccountAddress }),
+      client.getChainId(),
+    ]);
 
-    const rawTx = new TxnBuilderTypes.RawTransaction(
+    const rawTx = new RawTransaction(
       // Transaction sender account address
-      TxnBuilderTypes.AccountAddress.fromHex(mutisigAccountAddress),
+      AccountAddress.from(mutisigAccountAddress),
       BigInt(sequenceNumber),
-      entryFunctionPayload,
+      new TransactionPayloadEntryFunction(entryFunctionPayload),
       // Max gas unit to spend
       BigInt(fee?.maxGasAmount ?? 100_00),
       // Gas price per unit
       BigInt(fee?.gasUnitPrice ?? 100),
       // Expiration timestamp. Transaction is discarded if it is not executed within 1000 seconds (16.6 minutes) from now.
       BigInt(Math.floor(Date.now() / 1000) + 1000),
-      new TxnBuilderTypes.ChainId(chainId),
+      new ChainId(chainId),
     );
 
     return { tx: rawTx, txId: undefined };
@@ -153,33 +161,35 @@ export default class MultiSignatureAptos extends Aptos {
 
   async sendTx(data: any): Promise<string> {
     const client = await this.getProvider();
-    const signingMessage = TransactionBuilder.getSigningMessage(data);
+    const signingMessage = generateSigningMessage(data);
     const { signatures, bitmap } = await this.collectSignatures(signingMessage);
-    const txnBuilder = new TransactionBuilderMultiEd25519((_: TxnBuilderTypes.SigningMessage) => {
-      // Bitmap masks which public key has signed transaction.
-      // See https://aptos-labs.github.io/ts-sdk-doc/classes/TxnBuilderTypes.MultiEd25519Signature.html#createBitmap
-      const encodedBitmap = TxnBuilderTypes.MultiEd25519Signature.createBitmap(bitmap);
 
-      // See https://aptos-labs.github.io/ts-sdk-doc/classes/TxnBuilderTypes.MultiEd25519Signature.html#constructor
-      const muliEd25519Sig = new TxnBuilderTypes.MultiEd25519Signature(
-        signatures.map((s) => new TxnBuilderTypes.Ed25519Signature(s)),
-        encodedBitmap,
-      );
+    const encodedBitmap = MultiEd25519Signature.createBitmap({ bits: bitmap });
 
-      return muliEd25519Sig;
-    }, this.deserialisePubKey(this.getPublicKey() as Buffer));
+    const muliEd25519Sig = new MultiEd25519Signature({ signatures: signatures.map((s) => new Ed25519Signature(s)), bitmap: encodedBitmap });
 
-    const bcsTxn = txnBuilder.sign(data);
-    const txRes = await client.submitSignedBCSTransaction(bcsTxn);
-    return txRes.hash;
+    const authenticator = new TransactionAuthenticatorMultiEd25519(this.deserialisePubKey(this.getPublicKey() as Buffer), muliEd25519Sig);
+
+    const bcsTxn = new SignedTransaction(data, authenticator);
+
+    const { data: postData } = await postAptosFullNode<Uint8Array, PendingTransactionResponse>({
+      aptosConfig: this.aptosConfig,
+      body: bcsTxn,
+      path: "transactions",
+      originMethod: "submitTransaction",
+      contentType: MimeType.BCS_SIGNED_TRANSACTION,
+    });
+
+    await client.waitForTransaction({ transactionHash: postData.hash });
+    return postData.hash;
   }
 
   getSigner(): Signer {
     if (this.signerInstance) return this.signerInstance;
     const pkey = Buffer.alloc(1025);
     const deserKey = this.deserialisePubKey(this.getPublicKey() as Buffer);
-    deserKey.public_keys.forEach((k, i) => {
-      pkey.set(k.value, i * 32);
+    deserKey.publicKeys.forEach((k, i) => {
+      pkey.set(k.toUint8Array(), i * 32);
     });
     pkey.set(Buffer.from(deserKey.threshold.toString()), 1024);
 
@@ -188,7 +198,6 @@ export default class MultiSignatureAptos extends Aptos {
 
   async ready(): Promise<void> {
     await super.ready();
-    this.accountInstance = new AptosAccount(undefined, this.address);
   }
 
   async verify(pub: any, data: Uint8Array, signature: Uint8Array): Promise<boolean> {


### PR DESCRIPTION
resolves https://github.com/Irys-xyz/js-sdk/issues/119

Aptos has a new TS SDK and it is encouraged to migrate over to the new one for a better support and project integrations.

Note: 
I tested the e2e Irys flow locally using local builds. I couldn't find any tests or documentation regarding contribution steps. Please let me know if anything else is needed to complete the pull request.

Some feedback to share while working on the irys source code:
1. Could be nice to type the input arguments to be easily used by other projects, for reference https://github.com/Irys-xyz/js-sdk/blob/main/src/node/base.ts#L93
2. Having the service full url we just uploaded files/folder to as part of the response can be very helpful
```
type UploadResponse = {
....
url:""
}
``` 