### PR TITLE
fix: Update Aptos SDK usage to fit new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "strip-ansi": "6.0.0"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.9.0",
+    "@aptos-labs/ts-sdk": "^1.26.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",

--- a/src/node/tokens/aptos.ts
+++ b/src/node/tokens/aptos.ts
@@ -17,7 +17,7 @@ import {
   AccountAuthenticatorEd25519,
   Ed25519Signature,
   SignedTransaction,
-  generateSigningMessage,
+  generateSigningMessageForTransaction,
 } from "@aptos-labs/ts-sdk";
 import type { UserTransactionResponse, PendingTransactionResponse } from "@aptos-labs/ts-sdk";
 import AsyncRetry from "async-retry";
@@ -106,6 +106,7 @@ export default class AptosConfig extends BaseNodeToken {
       signer.sign = this.signingFn; // override signer fn
       return (this.signerInstance = signer);
     } else {
+      // @ts-expect-error private field use
       return (this.signerInstance = new AptosSigner(this.accountInstance!.privateKey.toString(), this.accountInstance!.publicKey.toString()));
     }
   }
@@ -205,7 +206,7 @@ export default class AptosConfig extends BaseNodeToken {
       },
     });
 
-    const message = generateSigningMessage(transaction);
+    const message = generateSigningMessageForTransaction(transaction);
 
     const signerSignature = await this.sign(message);
 

--- a/src/node/tokens/multiAptos.ts
+++ b/src/node/tokens/multiAptos.ts
@@ -20,11 +20,11 @@ import {
   TransactionAuthenticatorMultiEd25519,
   TransactionPayloadEntryFunction,
   U64,
-  generateSigningMessage,
   parseTypeTag,
   postAptosFullNode,
   AccountAuthenticatorEd25519,
   TransactionAuthenticatorEd25519,
+  generateSigningMessageForTransaction,
 } from "@aptos-labs/ts-sdk";
 // import Utils from "../../common/utils";
 
@@ -160,7 +160,7 @@ export default class MultiSignatureAptos extends Aptos {
 
   async sendTx(data: any): Promise<string> {
     const client = await this.getProvider();
-    const signingMessage = generateSigningMessage(data);
+    const signingMessage = generateSigningMessageForTransaction(data);
     const { signatures, bitmap } = await this.collectSignatures(signingMessage);
 
     const encodedBitmap = MultiEd25519Signature.createBitmap({ bits: bitmap });
@@ -202,5 +202,4 @@ export default class MultiSignatureAptos extends Aptos {
   async verify(pub: any, data: Uint8Array, signature: Uint8Array): Promise<boolean> {
     return await MultiSignatureAptosSigner.verify(pub, data, signature);
   }
-
 }

--- a/src/web/tokens/aptos.ts
+++ b/src/web/tokens/aptos.ts
@@ -9,8 +9,8 @@ import {
   AccountAuthenticatorEd25519,
   Ed25519Signature,
   SignedTransaction,
-  generateSigningMessage,
   generateSignedTransaction,
+  generateSigningMessageForTransaction,
 } from "@aptos-labs/ts-sdk";
 import type { Signer } from "arbundles";
 import { InjectedAptosSigner, AptosSigner } from "arbundles/web";
@@ -218,7 +218,7 @@ export default class AptosConfig extends BaseWebToken {
     // @ts-expect-error type issue
     const transaction = await client.transaction.build.simple(txData);
 
-    const message = generateSigningMessage(transaction);
+    const message = generateSigningMessageForTransaction(transaction);
 
     const signerSignature = await this.sign(message);
 


### PR DESCRIPTION
This PR updates the Aptos SDK to 1.26.0 and makes the required changes to usage of the Aptos SDK API